### PR TITLE
Remove hardcoded test User properties #11

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --require should
 --reporter dot
+--timeout 10000

--- a/test/northstar-client.test.js
+++ b/test/northstar-client.test.js
@@ -70,6 +70,7 @@ describe('NorthstarClient', () => {
 
       // Just ensure presence.
       user.should.have.properties(publicUserProperties);
+      user.should.not.have.properties(privateUserProperties);
     }
 
     // Constructor.
@@ -123,8 +124,8 @@ describe('NorthstarClient', () => {
       user.should.be.an.instanceof(NorthstarUserAuthorized);
 
       // Just ensure presence.
-      user.should.have.properties(privateUserProperties);
       user.should.have.properties(publicUserProperties);
+      user.should.have.properties(privateUserProperties);
     }
 
     /**

--- a/test/northstar-client.test.js
+++ b/test/northstar-client.test.js
@@ -20,6 +20,22 @@ const publicUserProperties = [
   'photo',
   'updatedAt',
 ];
+const privateUserProperties = [
+  'addrCity',
+  'addrStreet1',
+  'addrStreet2',
+  'addrState',
+  'addrZip',
+  'birthdate',
+  'email',
+  'interests',
+  'lastName',
+  'mobile',
+  'mobilecommonsID',
+  'mobilecommonsStatus',
+  'parseInstallationIds',
+  'source',
+];
 
 /**
  * Test Northstar Nodejs client.
@@ -105,23 +121,6 @@ describe('NorthstarClient', () => {
       // Ensure result to be an instance of NorthstarUserAuthorized.
       user.should.be.an.instanceof(NorthstarUser);
       user.should.be.an.instanceof(NorthstarUserAuthorized);
-
-      const privateUserProperties = [
-        'addrCity',
-        'addrStreet1',
-        'addrStreet2',
-        'addrState',
-        'addrZip',
-        'birthdate',
-        'email',
-        'interests',
-        'lastName',
-        'mobile',
-        'mobilecommonsID',
-        'mobilecommonsStatus',
-        'parseInstallationIds',
-        'source',
-      ];
 
       // Just ensure presence.
       user.should.have.properties(privateUserProperties);

--- a/test/northstar-client.test.js
+++ b/test/northstar-client.test.js
@@ -8,6 +8,19 @@ const NorthstarClient = require('../lib/northstar-client');
 const NorthstarUser = require('../lib/northstar-user');
 const NorthstarUserAuthorized = require('../lib/northstar-user-authorized');
 
+const publicUserProperties = [
+  'country',
+  'createdAt',
+  'drupalID',
+  'firstName',
+  'lastInitial',
+  'id',
+  'isAuthorized',
+  'language',
+  'photo',
+  'updatedAt',
+];
+
 /**
  * Test Northstar Nodejs client.
  */
@@ -39,20 +52,8 @@ describe('NorthstarClient', () => {
       // Ensure result to be an instance of NorthstarUser.
       user.should.be.an.instanceof(NorthstarUser);
 
-      // Ensure properties and test values.
-      user.should.have.properties({
-        isAuthorized: false,
-        id: '5480c950bffebc651c8b456f',
-        firstName: 'test',
-        lastInitial: 'L',
-        photo: 'https://avatar.dosomething.org/uploads/avatars/5480c950bffebc651c8b456f.jpeg',
-        language: 'en-global',
-        country: 'US',
-        drupalID: '187',
-      });
-
       // Just ensure presence.
-      user.should.have.properties(['updatedAt', 'createdAt']);
+      user.should.have.properties(publicUserProperties);
     }
 
     // Constructor.
@@ -105,39 +106,26 @@ describe('NorthstarClient', () => {
       user.should.be.an.instanceof(NorthstarUser);
       user.should.be.an.instanceof(NorthstarUserAuthorized);
 
-      // Ensure properties and test values.
-      user.should.have.properties({
-        isAuthorized: true,
-        id: '5480c950bffebc651c8b456f',
-        firstName: 'test',
-        lastName: 'Last',
-        lastInitial: 'L',
-        photo: 'https://avatar.dosomething.org/uploads/avatars/5480c950bffebc651c8b456f.jpeg',
-        email: 'test@dosomething.org',
-        mobile: '5555555555',
-        interests: [
-          'interest number 1',
-          'int num 2',
-        ],
-        birthdate: '1989-05-04 00:00:00',
-        addrStreet1: '123',
-        addrStreet2: '456',
-        addrCity: 'Paris',
-        addrState: 'Florida',
-        addrZip: '555555',
-        source: 'phoenix',
-        mobilecommonsID: null,
-        parseInstallationIds: [
-          'parse-test',
-        ],
-        mobilecommonsStatus: null,
-        language: 'en-global',
-        country: 'US',
-        drupalID: '187',
-      });
+      const privateUserProperties = [
+        'addrCity',
+        'addrStreet1',
+        'addrStreet2',
+        'addrState',
+        'addrZip',
+        'birthdate',
+        'email',
+        'interests',
+        'lastName',
+        'mobile',
+        'mobilecommonsID',
+        'mobilecommonsStatus',
+        'parseInstallationIds',
+        'source',
+      ];
 
       // Just ensure presence.
-      user.should.have.properties(['updatedAt', 'createdAt']);
+      user.should.have.properties(privateUserProperties);
+      user.should.have.properties(publicUserProperties);
     }
 
     /**


### PR DESCRIPTION
#### What's this PR do?

Removes checks for hardcoded test user data in the `unauthorizedTestUser` and `authorizedTestUser` functions.
#### How should this be reviewed?

Run `npm test` and verify all tests pass.
#### Any background context you want to provide?

I agree with @DFurnes we are better off avoiding [hardcoding test user data](https://github.com/DoSomething/northstar-js/issues/11#issuecomment-246496549). This would prove especially tricky for adding test cases for #13
#### Relevant tickets

Fixes #11 
