### PR TITLE
Adds northstar-endpoint-users

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Currently this is Node.js implementation only.
 TODO: explain dotenv usage, example `.env` file:
 
 ```
-DS_REST_API_BASEURI=https://northstar-qa.dosomething.org/v1/users
+DS_REST_API_BASEURI=https://northstar-qa.dosomething.org/v1
 DS_REST_API_KEY=your_secret_key
 ```

--- a/lib/northstar-client.js
+++ b/lib/northstar-client.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const request = require('superagent');
-const NorthstarUser = require('./northstar-user');
-const NorthstarUserAuthorized = require('./northstar-user-authorized');
+const NorthstarEndpointUsers = require('./northstar-endpoint-users');
 
 /**
  * NorthstarClient
@@ -28,16 +27,9 @@ class NorthstarClient {
 
     // Defaults.
     this.VERSION = VERSION;
-  }
 
-  /**
-   * Get single user.
-   */
-  getUser(type, id) {
-    // TODO: check type to be in allowed data.
-    return this
-      .executeGet(`users/${type}/${id}`)
-      .then(response => this.parseUser(response));
+      // Endpoints.
+    this.Users = new NorthstarEndpointUsers(this);
   }
 
   /**
@@ -54,23 +46,6 @@ class NorthstarClient {
     }
 
     return agent;
-  }
-
-  /**
-   * Helper function to parse response body to a NorthstarUser.
-   */
-  parseUser(response) {
-    if (!response.body.data) {
-      throw new Error('Cannot parse API response as a NorthstarUser.');
-    }
-
-    let result;
-    if (this.authorized) {
-      result = new NorthstarUserAuthorized(response.body.data);
-    } else {
-      result = new NorthstarUser(response.body.data);
-    }
-    return result;
   }
 
 }

--- a/lib/northstar-client.js
+++ b/lib/northstar-client.js
@@ -36,7 +36,7 @@ class NorthstarClient {
   getUser(type, id) {
     // TODO: check type to be in allowed data.
     return this
-      .executeGet(`${type}/${id}`)
+      .executeGet(`users/${type}/${id}`)
       .then(response => this.parseUser(response));
   }
 

--- a/lib/northstar-endpoint-users.js
+++ b/lib/northstar-endpoint-users.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const NorthstarEndpoint = require('./northstar-endpoint');
+const NorthstarUser = require('./northstar-user');
+const NorthstarUserAuthorized = require('./northstar-user-authorized');
+
+/**
+ * NorthstarEndpointUsers.
+ */
+
+class NorthstarEndpointUsers extends NorthstarEndpoint {
+
+  constructor(client) {
+    super(client);
+    this.endpoint = 'users';
+  }
+
+  /**
+   * Get single user.
+   */
+  getUser(type, id) {
+    // TODO: check type to be in allowed data.
+    return this.client
+      .executeGet(`${this.endpoint}/${type}/${id}`)
+      .then(response => this.parseUser(response));
+  }
+
+  /**
+   * Helper function to parse response body to a NorthstarUser.
+   */
+  parseUser(response) {
+    if (!response.body.data) {
+      throw new Error('Cannot parse API response as a NorthstarUser.');
+    }
+
+    let result;
+    if (this.client.authorized) {
+      result = new NorthstarUserAuthorized(response.body.data);
+    } else {
+      result = new NorthstarUser(response.body.data);
+    }
+    return result;
+  }
+
+}
+
+module.exports = NorthstarEndpointUsers;

--- a/lib/northstar-endpoint.js
+++ b/lib/northstar-endpoint.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * NorthstarEndpoint.
+ */
+
+class NorthstarEndpoint {
+
+  constructor(client) {
+    this.client = client;
+  }
+
+  parseResponse(response) {
+    if (!response.body) {
+      throw new Error('Cannot parse API response.');
+    }
+    return response.body;
+  }
+
+  parseStringResponse(response) {
+    if (!response.body) {
+      throw new Error('Cannot parse API response.');
+    }
+    // When a string is returned instead of a JSON, it is formatted
+    // as a single-element array containing this string.
+    const arrayResponse = response.body;
+    return String(arrayResponse[0]);
+  }
+
+}
+
+module.exports = NorthstarEndpoint;

--- a/test/northstar-client.test.js
+++ b/test/northstar-client.test.js
@@ -36,6 +36,7 @@ const privateUserProperties = [
   'parseInstallationIds',
   'source',
 ];
+const testUserId = '5480c950bffebc651c8b456f';
 
 /**
  * Test Northstar Nodejs client.
@@ -95,16 +96,17 @@ describe('NorthstarClient', () => {
     });
 
     // Get single user.
+    // @todo: Create test files per endpoint?
     describe('getUser()', () => {
       // Check getUser method.
       it('getUser() should be exposed', () => {
-        getUnauthorizedClient().getUser.should.be.a.Function();
+        getUnauthorizedClient().Users.getUser.should.be.a.Function();
       });
 
       // By id.
       it('by id should return correct Northstar user', () => {
         const client = getUnauthorizedClient();
-        const response = client.getUser('id', '5480c950bffebc651c8b456f');
+        const response = client.Users.getUser('id', testUserId);
 
         // Check response to be a Promise.
         response.should.be.a.Promise();
@@ -133,7 +135,7 @@ describe('NorthstarClient', () => {
      */
     function testUserBy(type, id) {
       const client = getAuthorizedClient();
-      const response = client.getUser(type, id);
+      const response = client.Users.getUser(type, id);
 
       // Check response to be a Promise.
       response.should.be.a.Promise();
@@ -160,7 +162,7 @@ describe('NorthstarClient', () => {
     describe('getUser()', () => {
       // By id.
       it('by id should return correct Northstar user', () => {
-        testUserBy('id', '5480c950bffebc651c8b456f');
+        testUserBy('id', testUserId);
       });
 
       // By email.


### PR DESCRIPTION
#### What's this PR do?

Adds a `northstar-endpoint` class and a child `northstar-endpoint-users` class:
- Refactors `client.getUser(type, id)` as `client.Users.get(type, id)`
- Removes `/users` namespace from `DS_REST_API_BASEURI` 
#### How should this be reviewed?

`npm test`
#### Any background context you want to provide?

Looking to add a `Users.create` next
#### Relevant tickets

Fixes #12
#### Checklist
- [x] Run tests
- [x] Add new or update existing tests if applicable
