### PR TITLE
Adds client.executePost, Users.create

### DIFF
--- a/lib/northstar-client.js
+++ b/lib/northstar-client.js
@@ -60,7 +60,7 @@ class NorthstarClient {
    */
   executePost(endpoint, data, query) {
     const agent = request
-      .get(`${this.baseURI}/${endpoint}`)
+      .post(`${this.baseURI}/${endpoint}`)
       .send(data)
       .accept('json');
 

--- a/lib/northstar-client.js
+++ b/lib/northstar-client.js
@@ -55,6 +55,25 @@ class NorthstarClient {
     return agent;
   }
 
+  /**
+   * Helper function to execute simple post.
+   */
+  executePost(endpoint, data, query) {
+    const agent = request
+      .get(`${this.baseURI}/${endpoint}`)
+      .send(data)
+      .accept('json');
+
+    if (this.authorized) {
+      agent.set('X-DS-REST-API-Key', this.apiKey);
+    }
+
+    if (query) {
+      agent.query(query);
+    }
+
+    return agent;
+  }
 }
 
 module.exports = NorthstarClient;

--- a/lib/northstar-endpoint-users.js
+++ b/lib/northstar-endpoint-users.js
@@ -19,6 +19,17 @@ class NorthstarEndpointUsers extends NorthstarEndpoint {
   }
 
   /**
+   * Create user.
+   */
+  create(data) {
+    // Note: if https://github.com/DoSomething/northstar/issues/406 happens,
+    // we can remove this create_drupal_user param.
+    return this.client
+      .executePost(`${this.endpoint}`, data, { create_drupal_user: 1 })
+      .then(response => this.parseUser(response));
+  }
+
+  /**
    * Get single user.
    */
   get(type, id) {

--- a/test/northstar-client.test.js
+++ b/test/northstar-client.test.js
@@ -179,9 +179,10 @@ describe('NorthstarClient', () => {
     // Create user.
     describe('Users.create()', () => {
       const client = getAuthorizedClient();
+      const timestamp = Date.now();
       const response = client.Users.create({
-        email: `test+${Date.now()}@dosomething.org`,
-        password: 'password',
+        email: `test+northstar-js+${timestamp}@dosomething.org`,
+        password: `password+${timestamp}`,
         source: 'northstar-js-test',
       });
 

--- a/test/northstar-client.test.js
+++ b/test/northstar-client.test.js
@@ -175,6 +175,19 @@ describe('NorthstarClient', () => {
         testUserBy('mobile', '5555555555');
       });
     });
+
+    // Create user.
+    describe('Users.create()', () => {
+      const client = getAuthorizedClient();
+      const response = client.Users.create({
+        email: `test+${Date.now()}@dosomething.org`,
+        password: 'password',
+        source: 'northstar-js-test',
+      });
+
+      response.should.be.a.Promise();
+      return response.should.eventually.match(authorizedTestUser);
+    });
   });
 
   describe('signups', () => {


### PR DESCRIPTION
#### What's this PR do?
- Adds a `executePost(endpoint, data, query)` function to our `northstar-client`
- Adds `Users.create(data)` which posts `data` to the Users endpoint
- Adds a test to create a fake user
#### How should this be reviewed?

Run `npm test`.
#### Any background context you want to provide?

Adding the `executePost` to work on #13, but we're unable to pass a User to the Signups endpoint (Refs https://github.com/DoSomething/northstar/issues/429)
#### Relevant tickets
#13, https://github.com/DoSomething/gambit/issues/606
#### Checklist
- [x] Run tests
- [x] Add new or update existing tests if applicable
