### PR TITLE
Adds reportback model and endpoint

### DIFF
--- a/lib/northstar-client.js
+++ b/lib/northstar-client.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const request = require('superagent');
-const NorthstarEndpointUsers = require('./northstar-endpoint-users');
-const NorthstarEndpointSignups = require('./northstar-endpoint-signups');
+const EndpointUsers = require('./northstar-endpoint-users');
+const EndpointSignups = require('./northstar-endpoint-signups');
+const EndpointReportbacks = require('./northstar-endpoint-reportbacks');
 
 /**
  * NorthstarClient
@@ -30,8 +31,9 @@ class NorthstarClient {
     this.VERSION = VERSION;
 
       // Endpoints.
-    this.Users = new NorthstarEndpointUsers(this);
-    this.Signups = new NorthstarEndpointSignups(this);
+    this.Users = new EndpointUsers(this);
+    this.Signups = new EndpointSignups(this);
+    this.Reportbacks = new EndpointReportbacks(this);
   }
 
   /**

--- a/lib/northstar-endpoint-reportbacks.js
+++ b/lib/northstar-endpoint-reportbacks.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const NorthstarEndpoint = require('./northstar-endpoint');
+const NorthstarReportback = require('./northstar-reportback');
+
+/**
+ * NorthstarEndpointReportbacks.
+ */
+
+class NorthstarEndpointReportbacks extends NorthstarEndpoint {
+
+  constructor(client) {
+    super(client);
+    this.endpoint = 'reportbacks';
+  }
+
+  /**
+   * Post reportback.
+   */
+  post(data) {
+    return this.client
+      .executePost(`${this.endpoint}`, data)
+      .then(response => this.parseReportback(response));
+  }
+
+  /**
+   * Helper function to parse response body to a NorthstarSignup.
+   */
+  parseReportback(response) {
+    if (!response.body.data) {
+      throw new Error('Cannot parse API get response as a NorthstarSignup.');
+    }
+
+    return new NorthstarReportback(response.body.data);
+  }
+
+}
+
+module.exports = NorthstarEndpointReportbacks;

--- a/lib/northstar-reportback.js
+++ b/lib/northstar-reportback.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * NorthstarReportback.
+ */
+
+class NorthstarReportback {
+
+  // Construct from JSON.
+  constructor(data) {
+    this.id = data.id;
+    this.campaign = data.campaign.id;
+    this.user = data.user.id;
+    this.createdAt = data.created_at;
+    this.quantity = data.quantity;
+    this.whyParticipated = data.why_participated;
+  }
+
+}
+
+module.exports = NorthstarReportback;

--- a/test/northstar-client.test.js
+++ b/test/northstar-client.test.js
@@ -8,6 +8,7 @@ const NorthstarClient = require('../lib/northstar-client');
 const NorthstarUser = require('../lib/northstar-user');
 const NorthstarUserAuthorized = require('../lib/northstar-user-authorized');
 const NorthstarSignup = require('../lib/northstar-signup');
+const NorthstarReportback = require('../lib/northstar-reportback');
 
 const publicUserProperties = [
   'country',
@@ -233,6 +234,39 @@ describe('NorthstarClient', () => {
 
         response.should.be.a.Promise();
         return response.should.eventually.match(testSignups);
+      });
+    });
+  });
+
+  describe('reportbacks', () => {
+    /**
+     * Helper: validate reportback object.
+     */
+    function testReportback(reportback) {
+      reportback.should.be.an.instanceof(NorthstarReportback);
+      reportback.should.have.properties(['id', 'campaign', 'user', 'createdAt', 'quantity']);
+    }
+
+
+    describe('Reportbacks.post()', () => {
+      it('should be exposed', () => {
+        getAuthorizedClient().Reportbacks.post.should.be.a.Function();
+      });
+
+      it('should return a Reportback', () => {
+        const client = getAuthorizedClient();
+        const response = client.Reportbacks.post({
+          nid: 1377,
+          uid: 5,
+          quantity: 30,
+          source: 'northstar-js-test',
+          caption: 'test',
+          why_participated: 'test',
+          file_url: 'https://pbs.twimg.com/profile_images/344513261577739462/0ffdff5acd5ff3bcd34c0cd10baf2a14_400x400.png',
+        });
+
+        response.should.be.a.Promise();
+        return response.should.eventually.match(testReportback);
       });
     });
   });


### PR DESCRIPTION
#### What's this PR do?
- Adds basic `northstar-reportback` model without any photos (just returns data on the Reportback, not Items)
- Adds `northstar-endpoint-reportbacks`, new `reportbacks.post(data)` function
- Adds a test for `reportbacks.test` but it fails with a 403 😿 
#### How should this be reviewed?

👀 `npm test`
#### Any background context you want to provide?

This may be the same issue as https://github.com/DoSomething/northstar/issues/429, but for the Northstar Reportbacks proxy instead of the Phoenix proxy.

 cc @DFurnes 
#### Relevant tickets
#13
#### Checklist
- [ ] Run tests
- [ ] Add new or update existing tests if applicable
