### PR TITLE
Moves executeGet and executePost functions to northstar-endpoint

### DIFF
--- a/lib/northstar-client.js
+++ b/lib/northstar-client.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const request = require('superagent');
 const NorthstarEndpointUsers = require('./northstar-endpoint-users');
 const NorthstarEndpointSignups = require('./northstar-endpoint-signups');
 
@@ -34,46 +33,6 @@ class NorthstarClient {
     this.Signups = new NorthstarEndpointSignups(this);
   }
 
-  /**
-   * Helper function to execute simple get.
-   */
-  executeGet(endpoint, query) {
-    const agent = request
-      .get(`${this.baseURI}/${endpoint}`)
-      .accept('json');
-
-    // Set api key.
-    if (this.authorized) {
-      agent.set('X-DS-REST-API-Key', this.apiKey);
-    }
-
-    // Set query string.
-    if (query) {
-      agent.query(query);
-    }
-
-    return agent;
-  }
-
-  /**
-   * Helper function to execute simple post.
-   */
-  executePost(endpoint, data, query) {
-    const agent = request
-      .post(`${this.baseURI}/${endpoint}`)
-      .send(data)
-      .accept('json');
-
-    if (this.authorized) {
-      agent.set('X-DS-REST-API-Key', this.apiKey);
-    }
-
-    if (query) {
-      agent.query(query);
-    }
-
-    return agent;
-  }
 }
 
 module.exports = NorthstarClient;

--- a/lib/northstar-endpoint-signups.js
+++ b/lib/northstar-endpoint-signups.js
@@ -22,7 +22,7 @@ class NorthstarEndpointSignups extends NorthstarEndpoint {
    */
   get(id) {
     // TODO: check type to be in allowed data.
-    return this.client
+    return this
       .executeGet(`${this.endpoint}/${id}`)
       .then(response => this.parseGet(response));
   }
@@ -31,7 +31,7 @@ class NorthstarEndpointSignups extends NorthstarEndpoint {
    * Get signups index.
    */
   index(query) {
-    return this.client
+    return this
       .executeGet(`${this.endpoint}`, query)
       .then(response => this.parseIndex(response));
   }

--- a/lib/northstar-endpoint-users.js
+++ b/lib/northstar-endpoint-users.js
@@ -24,7 +24,7 @@ class NorthstarEndpointUsers extends NorthstarEndpoint {
   create(data) {
     // Note: if https://github.com/DoSomething/northstar/issues/406 happens,
     // we can remove this create_drupal_user param.
-    return this.client
+    return this
       .executePost(`${this.endpoint}`, data, { create_drupal_user: 1 })
       .then(response => this.parseUser(response));
   }
@@ -34,7 +34,7 @@ class NorthstarEndpointUsers extends NorthstarEndpoint {
    */
   get(type, id) {
     // TODO: check type to be in allowed data.
-    return this.client
+    return this
       .executeGet(`${this.endpoint}/${type}/${id}`)
       .then(response => this.parseUser(response));
   }

--- a/lib/northstar-endpoint.js
+++ b/lib/northstar-endpoint.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const request = require('superagent');
+
 /**
  * NorthstarEndpoint.
  */
@@ -8,6 +10,47 @@ class NorthstarEndpoint {
 
   constructor(client) {
     this.client = client;
+  }
+
+  /**
+   * Helper function to execute simple get.
+   */
+  executeGet(endpoint, query) {
+    const agent = request
+      .get(`${this.client.baseURI}/${endpoint}`)
+      .accept('json');
+
+    // Set api key.
+    if (this.authorized) {
+      agent.set('X-DS-REST-API-Key', this.apiKey);
+    }
+
+    // Set query string.
+    if (query) {
+      agent.query(query);
+    }
+
+    return agent;
+  }
+
+  /**
+   * Helper function to execute simple post.
+   */
+  executePost(endpoint, data, query) {
+    const agent = request
+      .post(`${this.baseURI}/${endpoint}`)
+      .send(data)
+      .accept('json');
+
+    if (this.authorized) {
+      agent.set('X-DS-REST-API-Key', this.apiKey);
+    }
+
+    if (query) {
+      agent.query(query);
+    }
+
+    return agent;
   }
 
   parseResponse(response) {


### PR DESCRIPTION
#### What's this PR do?

Moves `executeGet` and `executePost` functions out of `northstar-client` and into `northstar-endpoint`, [matching how the `phoenix-endpoint` works in Phoenix JS.](https://github.com/DoSomething/phoenix-js/blob/75c638f46236ef7bd9a6f9f4cf684755612e647e/lib/phoenix-endpoint.js#L31)
