### PR TITLE
Fixes NorthstarEndpoint authorized check

### DIFF
--- a/lib/northstar-endpoint.js
+++ b/lib/northstar-endpoint.js
@@ -21,8 +21,8 @@ class NorthstarEndpoint {
       .accept('json');
 
     // Set api key.
-    if (this.authorized) {
-      agent.set('X-DS-REST-API-Key', this.apiKey);
+    if (this.client.authorized) {
+      agent.set('X-DS-REST-API-Key', this.client.apiKey);
     }
 
     // Set query string.
@@ -42,8 +42,8 @@ class NorthstarEndpoint {
       .send(data)
       .accept('json');
 
-    if (this.authorized) {
-      agent.set('X-DS-REST-API-Key', this.apiKey);
+    if (this.client.authorized) {
+      agent.set('X-DS-REST-API-Key', this.client.apiKey);
     }
 
     if (query) {


### PR DESCRIPTION
#### What's this PR do?

Actually sets our `X-DS-REST-API-Key`.
#### How should this be reviewed?

`npm test` passes -- but it passed before too, mainly because we're only checking for the existence of properties in the returned User object.
#### Any background context you want to provide?

Bumps up priority #25 a little bit for better testing coverage. For now this unblocks work on https://github.com/DoSomething/gambit/issues/636
#### Relevant tickets

Fixes #28 
